### PR TITLE
Aws eb

### DIFF
--- a/flask_project/app_config.py
+++ b/flask_project/app_config.py
@@ -8,8 +8,17 @@ try:
     from secret import OAUTH_CONSUMER_KEY, OAUTH_SECRET, SENTRY_DSN
 except ImportError:
     THE_SECRET_KEY = os.environ['SECRET_KEY']
-    OAUTH_CONSUMER_KEY = os.environ['OAUTH_CONSUMER_KEY']
-    OAUTH_SECRET = os.environ['OAUTH_SECRET']
+
+    if 'OAUTH_CONSUMER_KEY' in os.environ:
+        OAUTH_CONSUMER_KEY = os.environ['OAUTH_CONSUMER_KEY']
+    else:
+        OAUTH_CONSUMER_KEY = 'SET_OAUTH_CONSUMER_KEY'
+
+    if 'OAUTH_SECRET' in os.environ:
+        OAUTH_SECRET = os.environ['OAUTH_SECRET']
+    else:
+        OAUTH_SECRET = 'SET_OAUTH_SECRET'
+
     SENTRY_DSN = os.environ['SENTRY_DSN']
 
 

--- a/flask_project/app_config.py
+++ b/flask_project/app_config.py
@@ -8,9 +8,9 @@ try:
     from secret import OAUTH_CONSUMER_KEY, OAUTH_SECRET, SENTRY_DSN
 except ImportError:
     THE_SECRET_KEY = os.environ['SECRET_KEY']
-    OAUTH_CONSUMER_KEY = ''
-    OAUTH_SECRET = ''
-    SENTRY_DSN = ''
+    OAUTH_CONSUMER_KEY = os.environ['OAUTH_CONSUMER_KEY']
+    OAUTH_SECRET = os.environ['OAUTH_SECRET']
+    SENTRY_DSN = os.environ['SENTRY_DSN']
 
 
 try:
@@ -30,7 +30,6 @@ class Config(object):
     OAUTH_SECRET = OAUTH_SECRET
     SENTRY_DSN = SENTRY_DSN
     MAX_AREA_SIZE = 320000000
-    
 
     # OSMCHA ATTRIBUTES
     _OSMCHA_DOMAIN = 'https://osmcha.mapbox.com/'
@@ -57,6 +56,7 @@ class StagingConfig(Config):
     if 'DATABASE_URL' in os.environ:
         DB_LOCATION = os.environ['DATABASE_URL']
 
+
 class AWSStagingConfig(Config):
     DEBUG = False
 
@@ -66,6 +66,7 @@ class AWSStagingConfig(Config):
             os.environ['RDS_PASSWORD'],
             os.environ['RDS_HOSTNAME'],
             os.environ['RDS_DB_NAME'])
+
 
 class AWSDevelopmentConfig(Config):
     """ AWS Development environment.
@@ -79,6 +80,7 @@ class AWSDevelopmentConfig(Config):
             os.environ['RDS_PASSWORD'],
             os.environ['RDS_HOSTNAME'],
             os.environ['RDS_DB_NAME'])
+
 
 class DevelopmentConfig(Config):
     """Development environment.
@@ -100,5 +102,5 @@ class TestingConfig(Config):
     PRESERVE_CONTEXT_ON_EXCEPTION = False
     if 'TESTDATABASE_URL' in os.environ:
         DB_LOCATION = os.environ['TESTDATABASE_URL']
-        
+
     DRIVER_PATH = os.path.abspath('./campaign_manager/test/chromedriver')


### PR DESCRIPTION
app_config still needs some refactoring.
we need a strong config to avoid errors.
env variables we need in:
- development: app_settings, database_url, dns_sentry, oauth(key,secret), attic, overpass
- test: app_settings, testdatabase_url, dns_sentry, oauth(key, secret), attic, overpass
these variables can be defined in local_env.py with try: from secret import *, * except ImportError:
this file cannot be commited
- test (travis): 
   - in travis.yml: app_settings, testdatabase_url, secret_key
   - in travis cli: aws(key, secret), dns_sentry
   - in app_config: oauth(key, secret)
- staging (aws eb): app_settings, dns_sentry, oauth(key, secret), secret_key, attic, overpass

